### PR TITLE
actinia api: bandref -> semantic_label

### DIFF
--- a/src/actinia_api/swagger2/actinia_core/schemas/raster_layer.py
+++ b/src/actinia_api/swagger2/actinia_core/schemas/raster_layer.py
@@ -67,7 +67,7 @@ class RasterInfoModel(Schema):
         'timestamp': {'type': 'string'},
         'title': {'type': 'string'},
         'west': {'type': 'string'},
-        'bandref': {'type': 'string'}
+        'semantic_label': {'type': 'string'}
     }
     example = {
         "cells": "2025000",


### PR DESCRIPTION
one instance of bandref was still present in the RasterInfoModel